### PR TITLE
Add possibility to view winter dynamic tarif event messages #63

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-alpine
 
-RUN apk add --no-cache gcc musl-dev
+RUN apk add --no-cache gcc musl-dev tzdata
 
 WORKDIR /usr/src/app
 

--- a/config_cron.yaml.sample
+++ b/config_cron.yaml.sample
@@ -1,0 +1,10 @@
+# THIS YAML CAN CHANGE IN THE FUTURE
+timeout: 30
+# If frequency is not set the "daemon" will collect the data only one time and stop
+# 6 hours
+#frequency: 8640
+accounts:
+- username: USERNAME@EMAIL
+  password: PASSWORD
+  contracts:
+    - id: CONTRACT_ID

--- a/entrypoint_cron.sh
+++ b/entrypoint_cron.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -e
+
+# Check user and password
+if [ -z "$PYHQ_USER" ] || [ -z "$PYHQ_PASSWORD" ]  && [ "$PYHQ_OUTPUT" != "MQTT" ]
+then
+    echo 'Error: No user or password. Set both environnement variables PYHQ_USER and PYHQ_PASSWORD or PYHQ_OUTPUT=MQTT'
+    exit 1
+fi
+
+# Output type
+if [ ! -z "$PYHQ_OUTPUT" ]
+then
+    case "$PYHQ_OUTPUT" in
+        "TEXT")
+            PYHQ_CMD_OUTPUT=""
+        ;;
+        "JSON")
+            PYHQ_CMD_OUTPUT="-j"
+        ;;
+        "INFLUXDB")
+            PYHQ_CMD_OUTPUT="-i"
+        ;;
+        "CONTRACTS")
+            PYHQ_CMD_OUTPUT="-l"
+        ;;
+    esac
+else
+    PYHQ_CMD_OUTPUT=""
+fi
+
+# Contract
+if [ ! -z "$PYHQ_CONTRACT" ]
+then
+    PYHQ_CMD_CONTRACT="-c $PYHQ_CONTRACT"
+fi
+
+# Config
+if [ -z "$CONFIG" ]
+then
+    export CONFIG="/etc/pyhydroquebec/pyhydroquebec.yaml"
+fi
+
+if [ "$PYHQ_OUTPUT" == "MQTT" ]
+then
+    echo '0  2  *  *  *    /usr/local/bin/mqtt_pyhydroquebec' > /etc/crontabs/root
+    crond -l 2 -f
+else
+    pyhydroquebec -u $PYHQ_USER -p $PYHQ_PASSWORD $PYHQ_CMD_OUTPUT $PYHQ_CMD_CONTRACT
+fi
+
+CMD ['crond', '-l 2', '-f']

--- a/entrypoint_cron.sh
+++ b/entrypoint_cron.sh
@@ -44,6 +44,7 @@ fi
 if [ "$PYHQ_OUTPUT" == "MQTT" ]
 then
     echo '0  2  *  *  *    /usr/local/bin/mqtt_pyhydroquebec' > /etc/crontabs/root
+    mqtt_pyhydroquebec
     crond -l 2 -f
 else
     pyhydroquebec -u $PYHQ_USER -p $PYHQ_PASSWORD $PYHQ_CMD_OUTPUT $PYHQ_CMD_CONTRACT

--- a/entrypoint_cron.sh
+++ b/entrypoint_cron.sh
@@ -44,7 +44,7 @@ fi
 if [ "$PYHQ_OUTPUT" == "MQTT" ]
 then
     echo '0  2  *  *  *    /usr/local/bin/mqtt_pyhydroquebec' > /etc/crontabs/root
-    mqtt_pyhydroquebec
+    mqtt_pyhydroquebec || true
     crond -l 2 -f
 else
     pyhydroquebec -u $PYHQ_USER -p $PYHQ_PASSWORD $PYHQ_CMD_OUTPUT $PYHQ_CMD_CONTRACT

--- a/pyhydroquebec/__main__.py
+++ b/pyhydroquebec/__main__.py
@@ -23,6 +23,7 @@ async def fetch_data(client, contract_id, fetch_hourly=False):
         if contract_id is None:
             client.logger.warn("Contract id not specified, using first available.")
 
+        await customer.fetch_common_data()
         await customer.fetch_current_period()
         await customer.fetch_annual_data()
         await customer.fetch_monthly_data()

--- a/pyhydroquebec/consts.py
+++ b/pyhydroquebec/consts.py
@@ -140,14 +140,15 @@ Contract: {0.contract_id}
 Balance: {0.balance:.2f} $
 """)
 
+# Add those 2 lines to COMMON_TPL if you need them and also uncomment them in customer.py
+#Adress Line 1: {d[adress_line_1]}
+#Adress Line 2: {d[adress_line_2]}
+
 COMMON_TPL = ("""
 Hydro Quebec common data
 ========================
 
 Tarif Code: {d[tarif_code]}
-
-Adress Line 1: {d[adress_line_1]}
-Adress Line 2: {d[adress_line_2]}
 
 Today Message: {d[today_message]}
 Tomorrow Message: {d[tomorrow_message]}

--- a/pyhydroquebec/consts.py
+++ b/pyhydroquebec/consts.py
@@ -46,6 +46,9 @@ HOURLY_DATA_URL_1 = ("{}/portail/fr/group/clientele/portrait-de-consommation/"
 HOURLY_DATA_URL_2 = ("{}/portail/fr/group/clientele/portrait-de-consommation/"
                      "resourceObtenirDonneesMeteoHoraires".format(HOST_SPRING))
 
+COMMON_DATA_URL = ("{}/portail/fr/group/clientele/portrait-de-consommation/"
+                   "resourceObtenirInfoCommunPortrait".format(HOST_SPRING))
+
 CURRENT_MAP = {'period_total_bill': {'raw_name': 'montantFacturePeriode',
                                      'unit': '$',
                                      'icon': 'mdi:currency-usd',
@@ -135,6 +138,19 @@ Contract: {0.contract_id}
 ===================
 
 Balance: {0.balance:.2f} $
+""")
+
+COMMON_TPL = ("""
+Hydro Quebec common data
+========================
+
+Tarif Code: {d[tarif_code]}
+
+Adress Line 1: {d[adress_line_1]}
+Adress Line 2: {d[adress_line_2]}
+
+Today Message: {d[today_message]}
+Tomorrow Message: {d[tomorrow_message]}
 """)
 
 CONSUMPTION_PROFILE_TPL = ("""

--- a/pyhydroquebec/customer.py
+++ b/pyhydroquebec/customer.py
@@ -1,6 +1,7 @@
 """PyHydroQuebec Client Module."""
 from datetime import datetime, timedelta
 import json
+import re
 
 from bs4 import BeautifulSoup
 import cachetools
@@ -316,12 +317,66 @@ class Customer():
         if not json_res.get('results'):
             return
 
+        today_list = re.findall(r"\b\d+\b",json_res['results']['zoneMessageHTMLAvisAujourdhui'].replace('&nbsp;',' '))
+        today_dict = {}
+        
+        if len(today_list) >= 4:
+            today_dict = {
+              "today_start_1": today_list[1],
+              "today_end_1": today_list[2],
+              "today_start_2": today_list[3],
+              "today_end_2": today_list[4],
+            }
+        elif len(today_list) >= 2:
+            if int(today_list[1]) >= 12:
+                today_dict = {
+                  "today_start_1": "",
+                  "today_end_1": "",
+                  "today_start_2": today_list[1],
+                  "today_end_2": today_list[2],
+                }
+            else:
+                today_dict = {
+                  "today_start_1": today_list[1],
+                  "today_end_1": today_list[2],
+                  "today_start_2": "",
+                  "today_end_2": "",
+                }
+
+        tomorrow_list = re.findall(r"\b\d+\b",json_res['results']['zoneMessageHTMLAvisDemain'].replace('&nbsp;',' '))
+        tomorrow_dict = {}
+
+        if len(tomorrow_list) >= 4:
+            tomorrow_dict = {
+              "tomorrow_start_1": tomorrow_list[1],
+              "tomorrow_end_1": tomorrow_list[2],
+              "tomorrow_start_2": tomorrow_list[3],
+              "tomorrow_end_2": tomorrow_list[4],
+            }
+        elif len(tomorrow_list) >= 2:
+            if int(tomorrow_list[1]) >= 12:
+                tomorrow_dict = {
+                  "tomorrow_start_1": "",
+                  "tomorrow_end_1": "",
+                  "tomorrow_start_2": tomorrow_list[1],
+                  "tomorrow_end_2": tomorrow_list[2],
+                }
+            else:
+                tomorrow_dict = {
+                  "tomorrow_start_1": tomorrow_list[1],
+                  "tomorrow_end_1": tomorrow_list[2],
+                  "tomorrow_start_2": "",
+                  "tomorrow_end_2": "",
+                }
+
         self._current_common_data = {
                 'tarif_code': json_res['results']['codeTarif'],
                 #'adress_line_1': json_res['results']['adresseLieuConsoPartie1'],
                 #'adress_line_2': json_res['results']['adresseLieuConsoPartie2'],
                 'today_message': json_res['results']['zoneMessageHTMLAvisAujourdhui'].replace('&nbsp;',' '),
-                'tomorrow_message': json_res['results']['zoneMessageHTMLAvisDemain'].replace('&nbsp;',' '), 
+                'today_times': json.dumps(today_dict),
+                'tomorrow_message': json_res['results']['zoneMessageHTMLAvisDemain'].replace('&nbsp;',' '),
+                'tomorrow_times': json.dumps(tomorrow_dict),
                 }
 
     @property

--- a/pyhydroquebec/customer.py
+++ b/pyhydroquebec/customer.py
@@ -320,8 +320,8 @@ class Customer():
                 'tarif_code': json_res['results']['codeTarif'],
                 #'adress_line_1': json_res['results']['adresseLieuConsoPartie1'],
                 #'adress_line_2': json_res['results']['adresseLieuConsoPartie2'],
-                'today_message': json_res['results']['zoneMessageHTMLAvisAujourdhui'],
-                'tomorrow_message': json_res['results']['zoneMessageHTMLAvisDemain'],
+                'today_message': json_res['results']['zoneMessageHTMLAvisAujourdhui'].replace('&nbsp;',' '),
+                'tomorrow_message': json_res['results']['zoneMessageHTMLAvisDemain'].replace('&nbsp;',' '), 
                 }
 
     @property

--- a/pyhydroquebec/customer.py
+++ b/pyhydroquebec/customer.py
@@ -317,23 +317,29 @@ class Customer():
         if not json_res.get('results'):
             return
 
-        today_list = re.findall(r"\b\d+\b",json_res['results']['zoneMessageHTMLAvisAujourdhui'].replace('&nbsp;',' '))
+        add_hours = 0
+        today_message = json_res['results']['zoneMessageHTMLAvisAujourdhui'].replace('&nbsp;',' ')
+
+        if today_message.find("p.m.") != -1 :
+            add_hours = 12
+
+        today_list = re.findall(r"\b\d+\b",today_message)
         today_dict = {}
-        
+
         if len(today_list) >= 4:
             today_dict = {
-              "today_start_1": today_list[1],
+              "today_start_1": int(today_list[1]),
               "today_end_1": today_list[2],
-              "today_start_2": today_list[3],
-              "today_end_2": today_list[4],
+              "today_start_2": str(int(today_list[3]) + add_hours),
+              "today_end_2": str(int(today_list[4]) + add_hours),
             }
         elif len(today_list) >= 2:
-            if int(today_list[1]) >= 12:
+            if int(today_list[1]) + add_hours >= 12:
                 today_dict = {
                   "today_start_1": "",
                   "today_end_1": "",
-                  "today_start_2": today_list[1],
-                  "today_end_2": today_list[2],
+                  "today_start_2": str(int(today_list[1]) + add_hours),
+                  "today_end_2": str(int(today_list[2]) + add_hours),
                 }
             else:
                 today_dict = {
@@ -343,23 +349,29 @@ class Customer():
                   "today_end_2": "",
                 }
 
-        tomorrow_list = re.findall(r"\b\d+\b",json_res['results']['zoneMessageHTMLAvisDemain'].replace('&nbsp;',' '))
+        add_hours = 0
+        tomorrow_message = json_res['results']['zoneMessageHTMLAvisDemain'].replace('&nbsp;',' ')
+
+        if tomorrow_message.find("p.m.") != -1 :
+            add_hours = 12
+
+        tomorrow_list = re.findall(r"\b\d+\b",tomorrow_message)
         tomorrow_dict = {}
 
         if len(tomorrow_list) >= 4:
             tomorrow_dict = {
-              "tomorrow_start_1": tomorrow_list[1],
+              "tomorrow_start_1": int(tomorrow_list[1]),
               "tomorrow_end_1": tomorrow_list[2],
-              "tomorrow_start_2": tomorrow_list[3],
-              "tomorrow_end_2": tomorrow_list[4],
+              "tomorrow_start_2": str(int(tomorrow_list[3]) + add_hours),
+              "tomorrow_end_2": str(int(tomorrow_list[4]) + add_hours),
             }
         elif len(tomorrow_list) >= 2:
-            if int(tomorrow_list[1]) >= 12:
+            if int(tomorrow_list[1]) + add_hours >= 12:
                 tomorrow_dict = {
                   "tomorrow_start_1": "",
                   "tomorrow_end_1": "",
-                  "tomorrow_start_2": tomorrow_list[1],
-                  "tomorrow_end_2": tomorrow_list[2],
+                  "tomorrow_start_2": str(int(tomorrow_list[1]) + add_hours),
+                  "tomorrow_end_2": str(int(tomorrow_list[2]) + add_hours),
                 }
             else:
                 tomorrow_dict = {
@@ -375,7 +387,7 @@ class Customer():
                 #'adress_line_2': json_res['results']['adresseLieuConsoPartie2'],
                 'today_message': json_res['results']['zoneMessageHTMLAvisAujourdhui'].replace('&nbsp;',' '),
                 'today_times': json.dumps(today_dict),
-                'tomorrow_message': json_res['results']['zoneMessageHTMLAvisDemain'].replace('&nbsp;',' '),
+                'tomorrow_message': tomorrow_message,
                 'tomorrow_times': json.dumps(tomorrow_dict),
                 }
 

--- a/pyhydroquebec/customer.py
+++ b/pyhydroquebec/customer.py
@@ -318,8 +318,8 @@ class Customer():
 
         self._current_common_data = {
                 'tarif_code': json_res['results']['codeTarif'],
-                'adress_line_1': json_res['results']['adresseLieuConsoPartie1'],
-                'adress_line_2': json_res['results']['adresseLieuConsoPartie2'],
+                #'adress_line_1': json_res['results']['adresseLieuConsoPartie1'],
+                #'adress_line_2': json_res['results']['adresseLieuConsoPartie2'],
                 'today_message': json_res['results']['zoneMessageHTMLAvisAujourdhui'],
                 'tomorrow_message': json_res['results']['zoneMessageHTMLAvisDemain'],
                 }

--- a/pyhydroquebec/mqtt_daemon.py
+++ b/pyhydroquebec/mqtt_daemon.py
@@ -128,6 +128,19 @@ class MqttHydroQuebec(mqtt_hass_base.MqttDevice):
                         topic=balance_topic,
                         payload=customer.balance)
 
+                # Current Common Data
+                await customer.fetch_common_data()
+
+                for data_name, data in customer.current_common_data.items():
+                    # Publish sensor
+                    common_data_topic = self._publish_sensor(data_name,
+                                                             customer.contract_id,
+                                                             device_class=None)
+                    # Send sensor data
+                    self.mqtt_client.publish(
+                            topic=common_data_topic,
+                            payload=data)
+
                 # Current period
                 for data_name, data in CURRENT_MAP.items():
                     # Publish sensor

--- a/pyhydroquebec/outputter.py
+++ b/pyhydroquebec/outputter.py
@@ -7,7 +7,7 @@ This module defines the different output functions:
 """
 import json
 
-from pyhydroquebec.consts import (OVERVIEW_TPL,
+from pyhydroquebec.consts import (OVERVIEW_TPL, COMMON_TPL,
                                   CONSUMPTION_PROFILE_TPL,
                                   YESTERDAY_TPL, ANNUAL_TPL, HOURLY_HEADER, HOURLY_TPL)
 
@@ -15,6 +15,7 @@ from pyhydroquebec.consts import (OVERVIEW_TPL,
 def output_text(customer, show_hourly=False):
     """Format data to get a readable output."""
     print(OVERVIEW_TPL.format(customer))
+    print(COMMON_TPL.format(d=customer.current_common_data))
     if customer.current_period['period_total_bill']:
         print(CONSUMPTION_PROFILE_TPL.format(d=customer.current_period))
     if customer.current_annual_data:
@@ -76,6 +77,7 @@ def output_json(customer, show_hourly=False):
         "customer_id": customer.customer_id,
         "balance": customer.balance
     }
+    out["common_data"] = customer.current_common_data
     if customer.current_period['period_total_bill']:
         out["current_period"] = customer.current_period
     if customer.current_annual_data:


### PR DESCRIPTION
This PR enable the capability to view the message for today and tomorrow for the winter Dynamic Tarif. It give you the same message as when you log into your account . Ex.: 'le 13 février, réduisez votre consommation d’électricité de 6h à 9h.' in MQTT sensor or command line. You can also have your type of account. Ex.: D and your street address for the account (uncomment 2 files if needed).

Thanks